### PR TITLE
Module Level Configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You can also configure a cache per module like so
 ```elixir
 defmodule Greeter do
   use Memoir,
-    name: :greeter_cache
+    name: :greeter_cache,
     adapter: Memoir.Adapters.MyAdapter,
     ttl: :timer.minutes(5)
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ def deps do
 end
 ```
 
+Start the application by adding it to your supervision tree:
+
+```elixir
+children = [
+  Memoir
+]
+```
+
 ## Usage
 
 Memoir is typically used to cache expensive function calls:
@@ -54,6 +62,22 @@ Memoir.get(:some_key)
 Memoir.delete(:some_key)
 Memoir.clear()
 ```
+
+You can also configure a cache per module like so
+```elixir
+defmodule Greeter do
+  use Memoir,
+    name: :greeter_cache
+    adapter: Memoir.Adapters.MyAdapter,
+    ttl: :timer.minutes(5)
+
+  def greet(name) do
+    cache({:greet, name}) do # This will use the configured cache
+      "Hello, #{name}!"
+    end
+  end
+end
+``` 
 
 ## Configuration
 

--- a/lib/memoir.ex
+++ b/lib/memoir.ex
@@ -73,8 +73,8 @@ defmodule Memoir do
       def fetch(key, opts \\ [], fun),
         do: Memoir.fetch(key, build_options(opts), fun)
 
-      def get(key),
-        do: Memoir.get(key)
+      def get(key, opts \\ []),
+        do: Memoir.get(key, build_options(opts))
 
       def put(key, value, opts \\ []),
         do: Memoir.put(key, value, build_options(opts))

--- a/lib/memoir/adapters/cachex.ex
+++ b/lib/memoir/adapters/cachex.ex
@@ -25,9 +25,9 @@ defmodule Memoir.Adapters.Cachex do
   end
 
   def handle_call({:put, key, value, opts}, _from, %{cache_name: cache_name} = state) do
-    ttl = Keyword.get(opts, :expire_in)
+    expire = Keyword.get(opts, :expire_in)
 
-    Cachex.put(cache_name, key, value, ttl: ttl)
+    Cachex.put(cache_name, key, value, expire: expire)
     {:reply, :ok, state}
   end
 


### PR DESCRIPTION
This PR add module-level configuration, allowing each module to define its caching strategy, including cache name, adapter, and TTL, without needing to pass options to every cache/2 call.

```elixir
defmodule Greeter do
  use Memoir,
    name: :greeter_cache,
    adapter: Memoir.Adapters.MyAdapter,
    ttl: :timer.minutes(5)

  def greet(name) do
    cache({:greet, name}) do # This will use the configured cache
      "Hello, #{name}!"
    end
  end
end
```

**Benefits**
- Cleaner code: Avoid repeating cache configuration for every cached function call.
- Centralized configuration: Module-level settings allow consistent caching behavior per module.
- Flexible defaults: Individual cache/2 calls can still override module defaults if needed.