### PR TITLE
ETS Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 <a href="https://discord.gg/code-society-823178343943897088">
   <img src="https://discordapp.com/api/guilds/823178343943897088/widget.png?style=shield" alt="Join on Discord">
 </a>
+<a href="https://hex.pm/packages/memoir">
+  <img src="https://img.shields.io/hexpm/v/memoir.svg" alt="Memoir">
+</a>
 <a href="https://opensource.org/licenses/gpl-3.0">
   <img src="https://img.shields.io/badge/License-GPL%203.0-blue.svg" alt="License: GPL 3.0">
 </a>
@@ -18,11 +21,9 @@
 
 - A clean `cache/3` block interface
 
-- Optional `@cache` decorators for function-level memoization
-
 - Pluggable backends (ETS, Cachex, or your own)
 
-- Minimal setup, maximum flexibility
+- Minimal setup
 
 ---
 
@@ -31,7 +32,7 @@
 ```elixir
 def deps do
   [
-    {:memoir, "~> 0.1.0"}
+    {:memoir, "~> 0.2.1"}
   ]
 end
 ```
@@ -71,7 +72,7 @@ Memoir.clear()
 You can configure Memoir in your config.exs:
 ```elixir
 config :memoir,
-  adapter: Memoir.Adapters.ETS,
+  adapter: Memoir.Adapters.Cachex,
   adapter_opts: [ttl: 300_000]
 ```
 

--- a/lib/memoir.ex
+++ b/lib/memoir.ex
@@ -45,22 +45,6 @@ defmodule Memoir do
     adapter_opts: [ttl: 300_000]
   ```
 
-  You can also configure a cache per module like so:
-
-  ```elixir
-  defmodule Greeter do
-    use Memoir,
-      name: :greeter_cache,
-      adapter: Memoir.Adapters.MyAdapter,
-      ttl: :timer.minutes(5)
-
-    def greet(name) do
-      cache({:greet, name}) do # This will use the configured cache
-        "Hello, #{name}!"
-      end
-    end
-  end
-  ```
   """
   use Supervisor
 

--- a/lib/memoir.ex
+++ b/lib/memoir.ex
@@ -65,7 +65,7 @@ defmodule Memoir do
     adapter_opts = Application.get_env(:memoir, :adapter_opts, [])
 
     children = [
-      {adapter, [adapter_opts]}
+      {adapter, adapter_opts}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/memoir/adapters/cachex.ex
+++ b/lib/memoir/adapters/cachex.ex
@@ -64,8 +64,4 @@ defmodule Memoir.Adapters.Cachex do
     Cachex.clear(cache_name)
     {:reply, :ok, state}
   end
-
-  def terminate(_reason, _state) do
-    :ok
-  end
 end

--- a/lib/memoir/adapters/cachex.ex
+++ b/lib/memoir/adapters/cachex.ex
@@ -2,35 +2,29 @@ defmodule Memoir.Adapters.Cachex do
   @moduledoc """
   A `Cachex`-based cache adapter with automatic `GenServer` management.
 
-  This adapter wraps [Cachex](https://hex.pm/packages/cachex) operations
-  (`get/2`, `put/4`, `delete/2`, `clear/1`) in a `GenServer` process,
-  so it can be used as part of the `Memoir` caching framework.
+  This adapter provide a wrapper around [Cachex's](https://hex.pm/packages/cachex) operations
+  (`get/2`, `put/4`, `delete/2`, `clear/1`), so it can be used as part of the `Memoir`
+  caching framework.
 
-  ## Features
-    * Starts and supervises a named `Cachex` cache instance.
-    * Provides `:get`, `:put`, `:delete`, and `:clear` calls through `GenServer`.
-    * Automatically handles already-started cache processes.
+  ## Usage
 
-  ## Options
-    * `:cache_name` — the name of the underlying Cachex cache (default: `:memoir_cachex`)
-    * Any other options supported by `Cachex.start_link/2`.
+  The adapter is used automatically through the Memoir.Adapter behavior:
 
-  ## Example
+      # Get a value
+      {:ok, value} = Memoir.Adapters.Cachex.get(:my_key)
 
-      iex> GenServer.call(pid, {:put, :foo, "bar", []})
-      :ok
+      # Put a value
+      :ok = Memoir.Adapters.Cachex.put(:my_key, "my_value")
 
-      iex> GenServer.call(pid, {:get, :foo})
-      {:ok, "bar"}
+      # Delete a key
+      :ok = Memoir.Adapters.Cachex.delete(:my_key)
 
-      iex> GenServer.call(pid, {:delete, :foo})
-      :ok
+      # Clear all entries
+      :ok = Memoir.Adapters.Cachex.clear()
 
-      iex> GenServer.call(pid, {:get, :foo})
-      {:error, :not_found}
+  ## Cachex configuration
 
-      iex> GenServer.call(pid, :clear)
-      :ok
+  - `:cache_name` - the name of Cachex's cache (default: `:memoir_cachex`)
   """
   use Memoir.Adapter
 
@@ -69,5 +63,9 @@ defmodule Memoir.Adapters.Cachex do
   def handle_call(:clear, _from, %{cache_name: cache_name} = state) do
     Cachex.clear(cache_name)
     {:reply, :ok, state}
+  end
+
+  def terminate(_reason, _state) do
+    :ok
   end
 end

--- a/lib/memoir/adapters/ets.ex
+++ b/lib/memoir/adapters/ets.ex
@@ -1,10 +1,19 @@
 defmodule Memoir.Adapters.ETS do
   @moduledoc """
-  ETS (Erlang Term Storage) cache adapter for Memoir with automatic GenServer management.
+  ETS (Erlang Term Storage) cache adapter for Memoir with automatic GenServer management and TTL support.
 
   This adapter provides a high-performance, in-memory caching solution using ETS tables.
   ETS tables offer excellent read performance and are suitable for applications that need
   fast cache access within a single node. It is the default adapter used by Memoir.
+
+  ## Features
+
+  - Automatic ETS table creation and management
+  - High-performance in-memory storage
+  - TTL (time-to-live) support with automatic expiration
+  - Periodic cleanup of expired entries
+  - Automatic cleanup on process termination
+  - Thread-safe operations via GenServer
 
   ## Usage
 
@@ -13,8 +22,14 @@ defmodule Memoir.Adapters.ETS do
       # Get a value
       {:ok, value} = Memoir.Adapters.ETS.get(:my_key)
 
-      # Put a value
+      # Put a value with default TTL
       :ok = Memoir.Adapters.ETS.put(:my_key, "my_value")
+
+      # Put a value with custom TTL (in milliseconds)
+      :ok = Memoir.Adapters.ETS.put(:my_key, "my_value", ttl: 60_000)
+
+      # Put a value that never expires
+      :ok = Memoir.Adapters.ETS.put(:my_key, "my_value", ttl: :infinity)
 
       # Delete a key
       :ok = Memoir.Adapters.ETS.delete(:my_key)
@@ -22,29 +37,70 @@ defmodule Memoir.Adapters.ETS do
       # Clear all entries
       :ok = Memoir.Adapters.ETS.clear()
 
+  ## Configuration
+
+  - `ttl`: Default TTL in milliseconds (default: 3600000 = 1 hour)
+  - `cleanup_interval`: How often to run cleanup in milliseconds (default: 5000 = 5 seconds)
+
   ## ETS Table Configuration
 
   The ETS table is created with the following options:
   - `:set` - Only one entry per key (no duplicates)
   - `:protected` - Owner process can read/write, other processes can read
   - `:named_table` - Table can be referenced by module name
+
+  ## TTL Implementation
+
+  Values are stored as `{value, expiration_timestamp}` tuples. The cleanup process
+  runs periodically to remove expired entries, and entries are also checked for
+  expiration during read operations.
   """
   use Memoir.Adapter
 
-  def init(_opts) do
+  @default_ttl :timer.hours(1)
+  @default_cleanup_interval :timer.seconds(5)
+
+  def init(opts) do
     table = :ets.new(__MODULE__, [:set, :protected, :named_table])
-    {:ok, %{table: table}}
+
+    ttl = Keyword.get(opts, :ttl, @default_ttl)
+    cleanup_interval = Keyword.get(opts, :cleanup_interval, @default_cleanup_interval)
+
+    schedule_cleanup(cleanup_interval)
+
+    {:ok, %{
+      table: table,
+      default_ttl: ttl,
+      cleanup_interval: cleanup_interval
+    }}
   end
 
   def handle_call({:get, key}, _from, %{table: table} = state) do
     case :ets.lookup(table, key) do
-      [{^key, value}] -> {:reply, {:ok, value}, state}
-      [] -> {:reply, {:error, :not_found}, state}
+      [{^key, {value, expiration}}] ->
+        if expired?(expiration) do
+          :ets.delete(table, key)
+          {:reply, {:error, :not_found}, state}
+        else
+          {:reply, {:ok, value}, state}
+        end
+      [] ->
+        {:reply, {:error, :not_found}, state}
     end
   end
 
-  def handle_call({:put, key, value, _opts}, _from, %{table: table} = state) do
-    :ets.insert(table, {key, value})
+  def handle_call({:put, key, value, opts}, _from, %{table: table, default_ttl: default_ttl} = state) do
+    ttl = Keyword.get(opts, :ttl, default_ttl)
+
+    expiration = case ttl do
+      :infinity -> :infinity
+      ttl_ms when is_integer(ttl_ms) and ttl_ms > 0 ->
+        System.monotonic_time(:millisecond) + ttl_ms
+      _ ->
+        System.monotonic_time(:millisecond) + default_ttl
+    end
+
+    :ets.insert(table, {key, {value, expiration}})
     {:reply, :ok, state}
   end
 
@@ -58,8 +114,41 @@ defmodule Memoir.Adapters.ETS do
     {:reply, :ok, state}
   end
 
+  def handle_info(:cleanup, %{table: table, cleanup_interval: cleanup_interval} = state) do
+    cleanup_expired_entries(table)
+    schedule_cleanup(cleanup_interval)
+    {:noreply, state}
+  end
+
   def terminate(_reason, %{table: table}) do
     :ets.delete(table)
     :ok
   end
+
+  defp schedule_cleanup(interval),
+    do: Process.send_after(self(), :cleanup, interval)
+
+  defp cleanup_expired_entries(table) do
+    now = System.monotonic_time(:millisecond)
+
+    match_spec = [
+      {{:"$1", {:"$2", :"$3"}},
+       [{:andalso, {:is_integer, :"$3"}, {:<, :"$3", {:const, now}}}],
+       [:"$1"]}
+    ]
+
+    expired_keys = :ets.select(table, match_spec)
+
+    Enum.each expired_keys, fn key ->
+      :ets.delete(table, key)
+    end
+
+    length(expired_keys)
+  end
+
+  defp expired?(:infinity),
+    do: false
+
+  defp expired?(expiration) when is_integer(expiration),
+    do: System.monotonic_time(:millisecond) > expiration
 end

--- a/lib/memoir/adapters/ets.ex
+++ b/lib/memoir/adapters/ets.ex
@@ -1,28 +1,65 @@
 defmodule Memoir.Adapters.ETS do
   @moduledoc """
-  Cachex-based cache adapter with automatic GenServer management.
+  ETS (Erlang Term Storage) cache adapter for Memoir with automatic GenServer management.
+
+  This adapter provides a high-performance, in-memory caching solution using ETS tables.
+  ETS tables offer excellent read performance and are suitable for applications that need
+  fast cache access within a single node. It is the default adapter used by Memoir.
+
+  ## Usage
+
+  The adapter is used automatically through the Memoir.Adapter behavior:
+
+      # Get a value
+      {:ok, value} = Memoir.Adapters.ETS.get(:my_key)
+
+      # Put a value
+      :ok = Memoir.Adapters.ETS.put(:my_key, "my_value")
+
+      # Delete a key
+      :ok = Memoir.Adapters.ETS.delete(:my_key)
+
+      # Clear all entries
+      :ok = Memoir.Adapters.ETS.clear()
+
+  ## ETS Table Configuration
+
+  The ETS table is created with the following options:
+  - `:set` - Only one entry per key (no duplicates)
+  - `:protected` - Owner process can read/write, other processes can read
+  - `:named_table` - Table can be referenced by module name
   """
   use Memoir.Adapter
 
-  # coveralls-ignore-start
   def init(_opts) do
-    {:ok, %{}}
+    table = :ets.new(__MODULE__, [:set, :protected, :named_table])
+    {:ok, %{table: table}}
   end
 
-  def handle_call({:get, _key}, _from, state) do
-    {:reply, nil, state}
+  def handle_call({:get, key}, _from, %{table: table} = state) do
+    case :ets.lookup(table, key) do
+      [{^key, value}] -> {:reply, {:ok, value}, state}
+      [] -> {:reply, {:error, :not_found}, state}
+    end
   end
 
-  def handle_call({:put, _key, _value, _opts}, _from, state) do
+  def handle_call({:put, key, value, _opts}, _from, %{table: table} = state) do
+    :ets.insert(table, {key, value})
     {:reply, :ok, state}
   end
 
-  def handle_call({:delete, _key}, _from, state) do
+  def handle_call({:delete, key}, _from, %{table: table} = state) do
+    :ets.delete(table, key)
     {:reply, :ok, state}
   end
 
-  def handle_call(:clear, _from, state) do
+  def handle_call(:clear, _from, %{table: table} = state) do
+    :ets.delete_all_objects(table)
     {:reply, :ok, state}
   end
-  # coveralls-ignore-stop
+
+  def terminate(_reason, %{table: table}) do
+    :ets.delete(table)
+    :ok
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Memoir.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/PenguinBoi12/memoir"
-  @version "0.1.0"
+  @version "0.2.1"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule Memoir.MixProject do
     [
       {:excoveralls, "~> 0.18", only: :test},
       {:meck, "~> 1.0.0", only: :test},
-      {:cachex, "~> 4.1.1", optional: true, only: [:dev, :test]}
+      {:cachex, "~> 4.1.1"}
     ]
   end
 

--- a/test/adapters/ets_test.exs
+++ b/test/adapters/ets_test.exs
@@ -1,3 +1,242 @@
 defmodule Memoir.Adapters.ETSTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
+  alias Memoir.Adapters.ETS
+
+  setup do
+    safe_stop_server()
+    :ok
+  end
+
+  describe "basic operations" do
+    test "put and get a value" do
+      assert :ok = ETS.put(:test_key, "test_value")
+      assert {:ok, "test_value"} = ETS.get(:test_key)
+    end
+
+    test "get non-existent key returns not_found" do
+      assert {:error, :not_found} = ETS.get(:non_existent)
+    end
+
+    test "put overwrites existing value" do
+      assert :ok = ETS.put(:key, "value1")
+      assert :ok = ETS.put(:key, "value2")
+      assert {:ok, "value2"} = ETS.get(:key)
+    end
+
+    test "delete removes a key" do
+      assert :ok = ETS.put(:key, "value")
+      assert {:ok, "value"} = ETS.get(:key)
+      assert :ok = ETS.delete(:key)
+      assert {:error, :not_found} = ETS.get(:key)
+    end
+
+    test "delete non-existent key succeeds" do
+      assert :ok = ETS.delete(:non_existent)
+    end
+
+    test "clear removes all entries" do
+      assert :ok = ETS.put(:key1, "value1")
+      assert :ok = ETS.put(:key2, "value2")
+      assert :ok = ETS.clear()
+      assert {:error, :not_found} = ETS.get(:key1)
+      assert {:error, :not_found} = ETS.get(:key2)
+    end
+  end
+
+  describe "TTL functionality" do
+    test "entries expire after TTL" do
+      assert :ok = ETS.put(:short_ttl, "value", ttl: 50)
+      assert {:ok, "value"} = ETS.get(:short_ttl)
+      
+      Process.sleep(100)
+      
+      assert {:error, :not_found} = ETS.get(:short_ttl)
+    end
+
+    test "entries with infinity TTL never expire" do
+      assert :ok = ETS.put(:infinite, "value", ttl: :infinity)
+      assert {:ok, "value"} = ETS.get(:infinite)
+      
+      Process.sleep(50)
+      assert {:ok, "value"} = ETS.get(:infinite)
+    end
+
+    test "custom TTL overrides default" do
+      safe_stop_server()
+
+      {:ok, _pid} = ETS.start_link(ttl: 1000)
+      
+      assert :ok = ETS.put(:default_ttl, "value1")
+      assert :ok = ETS.put(:custom_ttl, "value2", ttl: 2000)
+
+      assert {:ok, "value1"} = ETS.get(:default_ttl)
+      assert {:ok, "value2"} = ETS.get(:custom_ttl)
+    end
+
+    test "zero or negative TTL uses default TTL" do
+      assert :ok = ETS.put(:zero_ttl, "value", ttl: 0)
+      assert :ok = ETS.put(:negative_ttl, "value", ttl: -100)
+      
+      assert {:ok, "value"} = ETS.get(:zero_ttl)
+      assert {:ok, "value"} = ETS.get(:negative_ttl)
+    end
+  end
+
+  describe "automatic cleanup" do
+    test "periodic cleanup removes expired entries" do
+      safe_stop_server()
+
+      {:ok, _pid} = ETS.start_link(cleanup_interval: 100)
+      
+      assert :ok = ETS.put(:expires_soon, "value1", ttl: 50)
+      assert :ok = ETS.put(:expires_later, "value2", ttl: 300)
+      assert :ok = ETS.put(:never_expires, "value3", ttl: :infinity)
+
+      assert {:ok, "value1"} = ETS.get(:expires_soon)
+      assert {:ok, "value2"} = ETS.get(:expires_later)
+      assert {:ok, "value3"} = ETS.get(:never_expires)
+      
+      Process.sleep(200)
+      
+      assert {:error, :not_found} = ETS.get(:expires_soon)
+      assert {:ok, "value2"} = ETS.get(:expires_later)
+      assert {:ok, "value3"} = ETS.get(:never_expires)
+    end
+  end
+
+  describe "GenServer management" do
+    test "automatically starts when not running" do
+      safe_stop_server()
+      
+      assert :ok = ETS.put(:auto_start, "value")
+      assert is_pid(Process.whereis(ETS))
+    end
+
+    test "multiple operations work with same server instance" do
+      pid1 = ensure_server_running()
+      assert :ok = ETS.put(:key1, "value1")
+      
+      pid2 = ensure_server_running()
+      assert :ok = ETS.put(:key2, "value2")
+      
+      assert pid1 == pid2
+      
+      assert {:ok, "value1"} = ETS.get(:key1)
+      assert {:ok, "value2"} = ETS.get(:key2)
+    end
+
+    test "server can be restarted" do
+      assert :ok = ETS.put(:before_restart, "value")
+      assert {:ok, "value"} = ETS.get(:before_restart)
+
+      safe_stop_server()      
+
+      assert {:error, :not_found} = ETS.get(:before_restart)
+      
+      assert :ok = ETS.put(:after_restart, "new_value")
+      assert {:ok, "new_value"} = ETS.get(:after_restart)
+    end
+  end
+
+  describe "data types" do
+    test "stores various Elixir terms" do
+      test_data = [
+        {:atom, :test_atom},
+        {:string, "test_string"},
+        {:integer, 42},
+        {:float, 3.14},
+        {:list, [1, 2, 3]},
+        {:tuple, {:ok, "result"}},
+        {:map, %{key: "value"}},
+        {:struct, %Date{year: 2023, month: 12, day: 25}}
+      ]
+      
+      for {key, value} <- test_data do
+        assert :ok = ETS.put(key, value)
+        assert {:ok, ^value} = ETS.get(key)
+      end
+    end
+  end
+
+  describe "concurrent access" do
+    test "handles concurrent operations" do
+      tasks = for i <- 1..10 do
+        Task.async(fn ->
+          key = "concurrent_#{i}"
+          value = "value_#{i}"
+          
+          assert :ok = ETS.put(key, value)
+          assert {:ok, ^value} = ETS.get(key)
+          assert :ok = ETS.delete(key)
+          assert {:error, :not_found} = ETS.get(key)
+        end)
+      end
+      
+      Enum.each(tasks, &Task.await/1)
+    end
+  end
+
+  describe "edge cases" do
+    test "handles nil values" do
+      assert :ok = ETS.put(:nil_key, nil)
+      assert {:ok, nil} = ETS.get(:nil_key)
+    end
+
+    test "handles empty string" do
+      assert :ok = ETS.put(:empty, "")
+      assert {:ok, ""} = ETS.get(:empty)
+    end
+
+    test "handles large values" do
+      large_value = String.duplicate("a", 10_000)
+      assert :ok = ETS.put(:large, large_value)
+      assert {:ok, ^large_value} = ETS.get(:large)
+    end
+
+    test "TTL works with complex keys" do
+      complex_key = {:compound, "key", 123}
+      assert :ok = ETS.put(complex_key, "value", ttl: 50)
+      assert {:ok, "value"} = ETS.get(complex_key)
+      
+      Process.sleep(100)
+      assert {:error, :not_found} = ETS.get(complex_key)
+    end
+  end
+
+  describe "error handling" do
+    test "handles invalid TTL gracefully" do
+      assert :ok = ETS.put(:invalid_ttl, "value", ttl: "invalid")
+      assert {:ok, "value"} = ETS.get(:invalid_ttl)
+    end
+
+    test "operations work after server crash and restart" do
+      assert :ok = ETS.put(:before_crash, "value")
+      
+      safe_stop_server()
+
+      assert :ok = ETS.put(:after_crash, "new_value")
+      assert {:ok, "new_value"} = ETS.get(:after_crash)
+
+      assert {:error, :not_found} = ETS.get(:before_crash)
+    end
+  end
+
+  defp ensure_server_running do
+    case Process.whereis(ETS) do
+      nil ->
+        {:ok, pid} = ETS.start_link()
+        pid
+      pid when is_pid(pid) ->
+        pid
+    end
+  end
+
+  defp safe_stop_server do
+    case Process.whereis(ETS) do
+      nil -> :ok
+      pid when is_pid(pid) -> 
+        GenServer.stop(ETS, :normal)
+        Process.sleep(10)
+    end
+  end
 end


### PR DESCRIPTION
This PR add a simple ETS adapter meant to be used as default caching strategy for Memoir.

- Automatic ETS table creation and management
- High-performance in-memory storage
- TTL (time-to-live) support with automatic expiration
- Periodic cleanup of expired entries
- Automatic cleanup on process termination
- Thread-safe operations via GenServer

## Usage

The adapter is used automatically through the Memoir.Adapter behavior:
```
# Get a value
{:ok, value} = Memoir.Adapters.ETS.get(:my_key)

# Put a value with default TTL
:ok = Memoir.Adapters.ETS.put(:my_key, "my_value")

# Put a value with custom TTL (in milliseconds)
:ok = Memoir.Adapters.ETS.put(:my_key, "my_value", ttl: 60_000)

# Put a value that never expires
:ok = Memoir.Adapters.ETS.put(:my_key, "my_value", ttl: :infinity)

# Delete a key
:ok = Memoir.Adapters.ETS.delete(:my_key)

# Clear all entries
:ok = Memoir.Adapters.ETS.clear()
```

## Configuration

- `ttl`: Default TTL in milliseconds (default: 3600000 = 1 hour)
- `cleanup_interval`: How often to run cleanup in milliseconds (default: 5000 = 5 seconds)

## ETS Table Configuration

The ETS table is created with the following options:
 - `:set` - Only one entry per key (no duplicates)
 - `:protected` - Owner process can read/write, other processes can read
 - `:named_table` - Table can be referenced by module name

## TTL Implementation

Values are stored as `{value, expiration_timestamp}` tuples. The cleanup process
runs periodically to remove expired entries, and entries are also checked for
expiration during read operations.
  